### PR TITLE
refactor(@sites/www): set color scheme cookie from client side

### DIFF
--- a/sites/www/.env
+++ b/sites/www/.env
@@ -3,7 +3,7 @@ CLOUDFLARE_TURNSTILE_SECRET_KEY="1x0000000000000000000000000000000AA"
 
 # cookies
 COOKIE_USER_ID="dev.sveltevietnam:user-id"
-COOKIE_COLOR_SCHEME="dev.sveltevietnam:color-scheme"
+PUBLIC_COOKIE_SCHEME="dev.sveltevietnam:color-scheme"
 COOKIE_LANGUAGE="dev.sveltevietnam:language"
 
 # public env

--- a/sites/www/src/hooks.server.ts
+++ b/sites/www/src/hooks.server.ts
@@ -1,17 +1,18 @@
 import type { Handle } from '@sveltejs/kit';
 
-import { COOKIE_COLOR_SCHEME, COOKIE_LANGUAGE, COOKIE_USER_ID } from '$env/static/private';
+import { COOKIE_LANGUAGE, COOKIE_USER_ID } from '$env/static/private';
+import { PUBLIC_COOKIE_SCHEME } from '$env/static/public';
 import { getLocaleFromUrl, localizeUrl } from '$shared/services/i18n';
 import type { ColorScheme } from '$shared/types';
 
-const COOKIE_CONFIG = { path: '/', secure: true, httpOnly: true };
+const COMMON_COOKIE_CONFIG = { path: '/', secure: true, httpOnly: true };
 
 export const handle: Handle = async ({ event, resolve }) => {
   const { locals, cookies, url, route, platform } = event;
 
   // Ensure that the user has a unique ID
   locals.userId = cookies.get(COOKIE_USER_ID) || crypto.randomUUID();
-  cookies.set(COOKIE_USER_ID, locals.userId, COOKIE_CONFIG);
+  cookies.set(COOKIE_USER_ID, locals.userId, COMMON_COOKIE_CONFIG);
 
   // return as is if fetching api routes
   if (route.id?.includes('(api)')) {
@@ -28,12 +29,15 @@ export const handle: Handle = async ({ event, resolve }) => {
     languageFromUrl = 'vi';
   }
 
-  locals.colorScheme = (cookies.get(COOKIE_COLOR_SCHEME) as ColorScheme) || 'system';
+  locals.colorScheme = (cookies.get(PUBLIC_COOKIE_SCHEME) as ColorScheme) || 'system';
   locals.language = languageFromUrl;
 
   // set cookies
-  cookies.set(COOKIE_COLOR_SCHEME, locals.colorScheme, COOKIE_CONFIG);
-  cookies.set(COOKIE_LANGUAGE, locals.language, COOKIE_CONFIG);
+  cookies.set(PUBLIC_COOKIE_SCHEME, locals.colorScheme, {
+    ...COMMON_COOKIE_CONFIG,
+    httpOnly: false,
+  });
+  cookies.set(COOKIE_LANGUAGE, locals.language, COMMON_COOKIE_CONFIG);
 
   const response = await resolve(event, {
     transformPageChunk: ({ html }) =>

--- a/sites/www/src/lib/shared/constants/index.ts
+++ b/sites/www/src/lib/shared/constants/index.ts
@@ -1,5 +1,4 @@
 export const LOAD_DEPENDENCIES = {
-  COLOR_SCHEME: 'site:color-scheme',
   LANGUAGE: 'site:language',
 } as const;
 

--- a/sites/www/src/routes/(api)/api/color-scheme/+server.ts
+++ b/sites/www/src/routes/(api)/api/color-scheme/+server.ts
@@ -1,9 +1,0 @@
-import { COOKIE_COLOR_SCHEME } from '$env/static/private';
-
-import type { RequestHandler } from './$types';
-
-export const POST = (async ({ request, cookies }) => {
-  const colorScheme = await request.text();
-  cookies.set(COOKIE_COLOR_SCHEME, colorScheme, { path: '/', secure: true, httpOnly: true });
-  return new Response(colorScheme);
-}) satisfies RequestHandler;

--- a/sites/www/src/routes/+layout.server.ts
+++ b/sites/www/src/routes/+layout.server.ts
@@ -1,10 +1,6 @@
-import { LOAD_DEPENDENCIES } from '$shared/constants';
-
 import type { LayoutServerLoadEvent } from './$types';
 
 export async function load({ url, locals, depends }: LayoutServerLoadEvent) {
-  depends(LOAD_DEPENDENCIES.COLOR_SCHEME);
-
   return {
     pathname: url.pathname, // to trigger when pathname changes
     colorScheme: locals.colorScheme,

--- a/sites/www/src/routes/[[lang=lang]]/+layout.svelte
+++ b/sites/www/src/routes/[[lang=lang]]/+layout.svelte
@@ -1,12 +1,11 @@
 <script lang="ts">
   import ModalPortal from '@svelte-put/modal/ModalPortal.svelte';
 
-  import { invalidate } from '$app/navigation';
   import { Footer } from '$client/components/Footer';
   import { Header } from '$client/components/Header';
   import { SplashScreen } from '$client/components/SplashScreen/index.js';
   import { modalStore } from '$client/modals';
-  import { LOAD_DEPENDENCIES } from '$shared/constants';
+  import { PUBLIC_COOKIE_SCHEME } from '$env/static/public';
   import type { ColorScheme } from '$shared/types';
 
   export let data;
@@ -17,11 +16,7 @@
     if (clientColorScheme === scheme) return;
     clientColorScheme = scheme;
     document.documentElement.dataset.colorScheme = scheme;
-    await fetch('/api/color-scheme', {
-      method: 'POST',
-      body: scheme,
-    });
-    invalidate(LOAD_DEPENDENCIES.COLOR_SCHEME);
+    document.cookie = `${PUBLIC_COOKIE_SCHEME}=${scheme}; path=/; SameSite=Lax; Secure`;
   }
 </script>
 


### PR DESCRIPTION
## Description

renders https://github.com/sveltevietnam/sveltevietnam.dev/issues/87

## Checklist

- [x] Does the project build? `pnpm build`
- [ ] Did the commits pass the pre-commit hook with without using `--no-verify`? stylelint currently failing, will fix later
